### PR TITLE
Dockerfile statements order fix

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:7
 
-RUN npm install
-
 COPY . .
+
+RUN npm install
 
 EXPOSE 80
 


### PR DESCRIPTION
npm install has to run AFTER copying dirs in Dockerfile, not before (need the presence of a package.json)