### PR TITLE
import db instance, not class

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -2,10 +2,10 @@
 const express = require('express');
 const config = require('config');
 const routes = require('./routes/mux');
-const store = require('./store/datastore');
+const db = require('./store/datastore');
 
-// initialize database
-let db = new store();
+// initialize database, to use the database simply import the same db
+// anywhere else in the codebase and use find(), insert(), etc...
 db.initialize(config.get("database.url"), config.get("database.name"));
 
 // define http endpoints

--- a/api/store/datastore.js
+++ b/api/store/datastore.js
@@ -112,4 +112,8 @@ class Datastore {
     }
 }
 
-module.exports = Datastore;
+// we export a single instance of a datastore.
+// it should be initialized in index.js; then
+// successive imports will import initialized db.
+let db = new Datastore();
+module.exports = db;


### PR DESCRIPTION
Instead of exporting the class, we should export an instance; then initialize it in index, and reuse it everywhere else.

Tested by adding a db insert operation to the healthcheck endpoint and verifying it indeed wrote to the db