### PR TITLE
Fix FCM token setting

### DIFF
--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -124,7 +124,7 @@ router.post('/fcmToken', middleware.verifyToken, async function(req, res) {
         await userSettings.save();
 
 	// return the received fcm token as confirmation
-	resp.json({token: userFcmToken});
+	res.json({token: userFcmToken});
     }
     catch (error) {
         console.log(error);


### PR DESCRIPTION
The /fcmToken endpoint currently times out because it doesnt return anything. here's proof of fix:

```
20:34 $ http POST http://localhost/fcmToken "Authorization: Bearer ${TOKEN}" fcmToken=MockToken
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 21
Content-Type: application/json; charset=utf-8
Date: Wed, 23 Oct 2019 03:34:34 GMT
ETag: W/"15-Qkjyyb/SgHnhSTrejwjU2WObIio"
X-Powered-By: Express

{
    "token": "MockToken"
}
```