### PR TITLE
subscribe to event event

### DIFF
--- a/api/routes/event.js
+++ b/api/routes/event.js
@@ -14,6 +14,9 @@ router.put("/event", middleware.verifyToken, eventHandlers.update);
 // invite people to an event
 router.post("/event/invite", middleware.verifyToken, eventHandlers.invite);
 
+// subscribe (going) to an event
+router.post("/event/subscribe", middleware.verifyToken, eventHandlers.subscribe);
+
 // get all public events within a given radius of user coordinates
 // which satisfy conditions in the request
 router.get("/event/search", middleware.verifyToken, eventHandlers.search);


### PR DESCRIPTION
closes https://github.com/adrianosela/mapp/issues/92

### Testing:

**Authenticated request to subscribe to an event**

```
17:49 $ http POST http://localhost/event/subscribe eventId=5daf9d7a50840c0008f154e6 "Authorization: Bearer ${TOKEN}"
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 20
Content-Type: text/html; charset=utf-8
Date: Fri, 01 Nov 2019 00:50:04 GMT
ETag: W/"14-xj6g1dyuH3FWKnHqMiXERtTJiAk"
X-Powered-By: Express

Subscribed to event!
```

**Resultant DB**

Event (see followers):
<img width="735" alt="Screen Shot 2019-10-31 at 5 51 07 PM" src="https://user-images.githubusercontent.com/16856511/67995357-3a06b700-fc07-11e9-9ee8-724d28fd2a15.png">

User (see subscribedEvents):
<img width="719" alt="Screen Shot 2019-10-31 at 5 51 19 PM" src="https://user-images.githubusercontent.com/16856511/67995361-3d01a780-fc07-11e9-8a38-6bb4beb364ee.png">
