### PR TITLE
Updated getPendingInvites to only return Eevent name and id

### DIFF
--- a/api/handlers/user.js
+++ b/api/handlers/user.js
@@ -107,7 +107,17 @@ let getPendingInvites = async function(req, res) {
         let pendingEvents = await Event.find({
             _id: { $in: user.pendingInvites }
         });
-        res.json(pendingEvents);
+
+        let response = [];
+        for (let event of pendingEvents) {
+            let eventObject = {
+                id: event._id,
+                name: event.name
+            };
+            response.push(eventObject);
+        }
+
+        res.json(response);
     }
     catch (e) {
         console.log(`[error] ${e}`);


### PR DESCRIPTION
Updated /user/pending call to return only events' name and id, instead of  whole event objects.