### PR TITLE
Implemented Search Events Functionality

### DIFF
--- a/api/handlers/event.js
+++ b/api/handlers/event.js
@@ -223,7 +223,7 @@ let invitePeople = async function(req, resp) {
 
 // get all events within a given radius of given latitude
 // and longitude, if event is marked as public
-let searchEvent = async function(req, resp) {
+let findEvents = async function(req, resp) {
     const longitude = req.query.longitude;
     const latitude = req.query.latitude;
     const radius = req.query.radius;
@@ -263,10 +263,47 @@ let searchEvent = async function(req, resp) {
     });
 };
 
+let searchEvents = async function(req, res) {
+    const userId = req.authorization.id;
+
+    const eventName = req.query.eventName;
+    const categories = req.query.categories;
+    
+    let query = {
+        $and: [
+            { name: { $regex: `^${eventName}`} },
+            { 
+                $or: [
+                    { public: true },
+                    { creator: userId },
+                    { followers: userId },
+                    { invited: userId }
+                ] 
+            }
+        ]
+    };
+
+    if (categories && categories.length != 0) {
+        query.$and.push({
+            categories: { $all: categories }
+        });
+    }
+
+    try {
+        let events = await Event.find(query);
+        res.json(events);
+    }
+    catch (e) {
+        console.log(`[error] ${e}`);
+        res.status(500).send("Could not search for events");
+    }
+};
+
 module.exports = {
     get: getEvent,
     create: createEvent,
     update: updateEvent,
     invite: invitePeople,
-    search: searchEvent
+    find: findEvents,
+    search: searchEvents
 };

--- a/api/handlers/event.js
+++ b/api/handlers/event.js
@@ -271,7 +271,7 @@ let searchEvents = async function(req, res) {
     
     let query = {
         $and: [
-            { name: { $regex: `^${eventName}`} },
+            { name: { $regex: `${eventName}`, $options: "$i" } },
             { 
                 $or: [
                     { public: true },

--- a/api/routes/event.js
+++ b/api/routes/event.js
@@ -16,6 +16,9 @@ router.post("/event/invite", middleware.verifyToken, eventHandlers.invite);
 
 // get all public events within a given radius of user coordinates
 // which satisfy conditions in the request
+router.get("/event/find", middleware.verifyToken, eventHandlers.find);
+
+// Get events for requesting user based on name
 router.get("/event/search", middleware.verifyToken, eventHandlers.search);
 
 module.exports = router;


### PR DESCRIPTION
Renamed GET /event/search -> /event/find (i.e. findEvents returns events near location).
Implemented new GET /event/search that will allow a user to search for an event which name is contains the `eventName` substring.

IMPORTANT: This GET /event/search is not the same one as the one that was deployed. @chrisneuf and @oleksandran please update the front end calls to make sure you now call GET /event/find where you call GET /event/search