### PR TITLE
hotfix user following

### DIFF
--- a/api/handlers/user.js
+++ b/api/handlers/user.js
@@ -75,6 +75,10 @@ let getFollowing = async function(req, res) {
             return res.status(404).send("User not found");
         }
 
+        if (!user.following || user.following.length === 0) {
+            return res.json([]);
+        }
+
         let following = User.find({
             _id: { $in: user.following }
         });


### PR DESCRIPTION
closes https://github.com/adrianosela/mapp/issues/145

our /user/following endpoint was always throwing 500s

```
18:33 $ http https://mapp-254321.appspot.com/user/following "Authorization: Bearer $TOKEN"
HTTP/1.1 500 Internal Server Error
Alt-Svc: quic=":443"; ma=2592000; v="46,43",h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000
Content-Length: 35
Content-Type: text/html; charset=utf-8
Date: Tue, 05 Nov 2019 02:33:58 GMT
ETag: W/"23-URK6DAgVQB6nKPXxsETUoWRoFKU"
Server: Google Frontend
X-Cloud-Trace-Context: 2f5bab612d156236b4b5c3d3c16b2880;o=1
X-Powered-By: Express

Could not retrieve user's following
```

Inspecting the logs we find:

```
2019-11-05 02:32:22 default[20191104t174748]  [error] TypeError: following is not iterable
2019-11-05 02:32:22 default[20191104t174748]  (node:7) UnhandledPromiseRejectionWarning: Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
2019-11-05 02:32:22 default[20191104t174748]      at ServerResponse.setHeader (_http_outgoing.js:470:11)
2019-11-05 02:32:22 default[20191104t174748]      at ServerResponse.header (/srv/node_modules/express/lib/response.js:771:10)
2019-11-05 02:32:22 default[20191104t174748]      at ServerResponse.send (/srv/node_modules/express/lib/response.js:170:12)
2019-11-05 02:32:22 default[20191104t174748]      at getFollowing (/srv/handlers/user.js:95:25)
2019-11-05 02:32:22 default[20191104t174748]      at process._tickCallback (internal/process/next_tick.js:68:7)
```

After the fix:

```
18:43 $ http http://localhost/user/following "Authorization: Bearer $TOKEN"
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 2
Content-Type: application/json; charset=utf-8
Date: Tue, 05 Nov 2019 02:46:07 GMT
ETag: W/"2-l9Fw4VUO7kr8CvBlt4zaMCqXZ0w"
X-Powered-By: Express

[]
```