### PR TITLE
Prevent Duplicate Entries

### DIFF
--- a/api/handlers/event.js
+++ b/api/handlers/event.js
@@ -76,7 +76,7 @@ let createEvent = async function(req, resp) {
         let event = await newEvent.save();
 
         let creatorUser = await User.findById(creator);
-        creatorUser.createdEvents.push(event._id);
+        creatorUser.createdEvents.addToSet(event._id);
         await creatorUser.save();
 
         if (invited != null && invited.length !== 0) {
@@ -84,7 +84,7 @@ let createEvent = async function(req, resp) {
                 _id: { $in: invited }
             });
             for (let user of users) {
-                user.pendingInvites.push(event._id);
+                user.pendingInvites.addToSet(event._id);
                 await user.save();
             }
 
@@ -216,8 +216,8 @@ let invitePeople = async function(req, resp) {
             _id: { $in: invited }
         });
         for (let user of users) {
-            event.invited.push(user._id);
-            user.pendingInvites.push(event._id);
+            event.invited.addToSet(user._id);
+            user.pendingInvites.addToSet(event._id);
             await user.save();
         }
 

--- a/api/handlers/user.js
+++ b/api/handlers/user.js
@@ -269,7 +269,7 @@ let unfollowUser = async function(req, res) {
         }
 
         user.following.pull(userToUnfollowId);
-        await user.save()
+        await user.save();
 
         userToUnfollow.followers.pull(user._id);
         await userToUnfollow.save();

--- a/api/handlers/user.js
+++ b/api/handlers/user.js
@@ -235,10 +235,10 @@ let followUser = async function(req, res) {
             return res.status(404).send("Requesting user not found");
         }
 
-        user.following.push(userToFollowId);
+        user.following.addToSet(userToFollowId);
         await user.save();
 
-        userToFollow.followers.push(user._id);
+        userToFollow.followers.addToSet(user._id);
         await userToFollow.save();
 
         res.send("Successfully followed requested user");
@@ -302,10 +302,10 @@ let subscribeToEvents = async function(req, res) {
 
         for (let event of events) {
             user.pendingInvites.pull(event._id);
-            user.subscribedEvents.push(event._id);
+            user.subscribedEvents.addToSet(event._id);
 
             event.invited.pull(user._id);
-            event.followers.push(userId);
+            event.followers.addToSet(userId);
             await event.save();
         }
 

--- a/api/handlers/user.js
+++ b/api/handlers/user.js
@@ -319,7 +319,7 @@ let subscribeToEvents = async function(req, res) {
     }
 };
 
-let unsubscribeToEvents = async function(req, res) {
+let unsubscribeFromEvents = async function(req, res) {
     const userId = req.authorization.id;
 
     const eventIds = req.body.eventIds;
@@ -383,6 +383,6 @@ module.exports = {
     follow: followUser,
     unfollow: unfollowUser,
     subscribe: subscribeToEvents,
-    unsubscribe: unsubscribeToEvents,
+    unsubscribe: unsubscribeFromEvents,
     search: searchUsers
 };


### PR DESCRIPTION
Added a couple of improvements to the backend. These include:
- Fixed a bug where get following and followers was returning 500
- Renamed some unsubscribeToEvents -> unsubscribeFromEvents for clarity
- Utilized addToSet to prevent duplicate entries in our schema arrays